### PR TITLE
Feature/fix docker cleanup

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -197,14 +197,14 @@ func RemoveImage(host, image string, force, noPrune bool) error {
 	} else if response.StatusCode == 409 {
 		bodyBytes, _ := ioutil.ReadAll(response.Body)
 		bodyString := string(bodyBytes)
-		if strings.Contains(bodyString, "image is referenced in multiple repositories") {
+		if strings.Contains(bodyString, "image is being used by running container") {
+			return nil
+		} else if strings.Contains(bodyString, "image is referenced in multiple repositories") {
 			log.Printf("%s must be fored because it is referenced in multiple repositories", image)
 			err := RemoveImage(host, image, true, false)
 			if err != nil {
 				return fmt.Errorf("%d: There was a error trying to remove %s from %s's filesystem", response.StatusCode, image, host)
 			}
-			return nil
-		} else if strings.Contains(bodyString, "image is being used by running container") {
 			return nil
 		}
 		return fmt.Errorf("%d: There was a conflict trying to remove %s from %s's filesystem", response.StatusCode, image, host)


### PR DESCRIPTION
Increased the Image structs Created, Size, and VirtualSize variables to handle larger hashes. Added logic to handle a 409 response due to an image having multiple tags. In our use case, we still want those images removed.