### PR TITLE
moved error handling up the function call stack

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -106,7 +106,7 @@ func getContainers(url string, queryStringParams map[string]string) (containers 
 		log.Fatal(err)
 	}
 
-	return nil, err
+	return containers, err
 }
 
 // RemoveContainer deletes the given container from the given host


### PR DESCRIPTION
This is specific to the docker clean up process, but if that is all that uses the go-utils, then it won't be an issue. This *I think* will hand errors up until they get back to Rundeck, where they are just logged an don't cause the process to halt.